### PR TITLE
Bazel BUILD targets for linux

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,11 +34,18 @@ cc_library(
 
 new_local_repository(
 	name = "linux_libs",
-	path = "/usr/lib",
+	path = "/usr/lib/x86_64-linux-gnu",
 	build_file_content = """
 cc_library(
 	name = "asound",
-	srcs = ["x86_64-linux-gnu/asound.so"],
+	srcs = ["libasound.so.2"],
+	deps = [":pthread"],
+	visibility = ["//visibility:public"],
+)
+
+cc_library(
+	name = "pthread",
+	srcs = ["libpthread.so"],
 	visibility = ["//visibility:public"],
 )
 """,

--- a/jukebox_test/demo/BUILD
+++ b/jukebox_test/demo/BUILD
@@ -20,3 +20,23 @@ cc_binary(
 		"//win/Sound:direct_sound",
 	],
 )
+
+cc_binary(
+	name = "main_linux",
+	data = [
+		"//jukebox_test/data:sound",
+	],
+	deps = [
+		":main",
+		"//jukebox/FileFormats:wave_file",  # because the factory implementation is there :-(
+		"//linux/Mixer:alsa_mixer",
+		"//linux/Sound:alsa_sound",
+	],
+	
+	# I am getting undefined reference to jukebox::factory::makeMixerImpl()
+	# even after adding "//linux/Mixer:alsa_mixer" dependency
+	# gcc is probably messing up with the linking settings.
+	# I have to manually include AlsaMixer.cpp as a source to get rid of this issue
+	# note that the windows target does not have this problem and it links properly
+	srcs = ["//linux/Mixer:AlsaMixer.cpp"],
+)

--- a/linux/Mixer/AlsaMixer.cpp
+++ b/linux/Mixer/AlsaMixer.cpp
@@ -13,11 +13,9 @@
     along with libjukebox.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <iostream>
 #include <exception>
-
-#include "Mixer/Mixer.h"
-#include "Mixer/AlsaMixer.h"
+#include "AlsaMixer.h"
+#include "jukebox/Mixer/Mixer.h"
 
 namespace jukebox {
 
@@ -35,7 +33,6 @@ void closeMixer(snd_mixer_t *handle) {
 }
 
 AlsaMixer::AlsaMixer(const std::string &devName, const std::string &element) :
-	MixerImpl(),
 	handlePtr(nullptr, closeMixer) {
 
 	snd_mixer_t *handle;

--- a/linux/Mixer/AlsaMixer.h
+++ b/linux/Mixer/AlsaMixer.h
@@ -13,13 +13,13 @@
     along with libjukebox.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LINUX_ALSAMIXER_H_
-#define LINUX_ALSAMIXER_H_
+#ifndef LIBJUKEBOX_LINUX_ALSAMIXER_2017_12_28_H_
+#define LIBJUKEBOX_LINUX_ALSAMIXER_2017_12_28_H_
 
 #include <memory>
 #include <alsa/asoundlib.h>
 
-#include "Mixer/MixerImpl.h"
+#include "jukebox/Mixer/MixerImpl.h"
 
 namespace jukebox {
 
@@ -38,10 +38,10 @@ private:
 	std::unique_ptr<snd_mixer_t, decltype(&closeMixer)> handlePtr;
 	snd_mixer_elem_t* element_handle = nullptr;
 	long minVolume, maxVolume;
-	AlsaMixer() = delete;
+
 	AlsaMixer(const std::string &devName, const std::string &element);
 };
 
 } /* namespace jukebox */
 
-#endif /* LINUX_ALSAMIXER_H_ */
+#endif

--- a/linux/Mixer/BUILD
+++ b/linux/Mixer/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+	name = "alsa_mixer",
+	srcs = ["AlsaMixer.cpp"],
+	hdrs = ["AlsaMixer.h"],
+	deps = [
+		"//jukebox/Mixer:mixer",
+		"//jukebox/Mixer:mixer_impl",
+		"@linux_libs//:asound",
+	],
+)

--- a/linux/Sound/AlsaHandle.cpp
+++ b/linux/Sound/AlsaHandle.cpp
@@ -21,9 +21,13 @@
 #define ALSA_DEVICE "sysdefault"
 #endif
 
+#ifndef ALSA_MIN_FRAMES
+#define ALSA_MIN_FRAMES 100
+#endif
+
 namespace {
 
-constexpr size_t minFrames = 100;
+constexpr size_t minFrames = ALSA_MIN_FRAMES;
 
 class StatusGuard {
 public:

--- a/linux/Sound/AlsaHandle.cpp
+++ b/linux/Sound/AlsaHandle.cpp
@@ -17,6 +17,10 @@
 #include "AlsaHandle.h"
 #include "jukebox/Sound/Sound.h"
 
+#ifndef ALSA_DEVICE
+#define ALSA_DEVICE "sysdefault"
+#endif
+
 namespace {
 
 constexpr size_t minFrames = 100;
@@ -56,7 +60,7 @@ AlsaHandle::AlsaHandle(SoundFile &file) :
 	handlePtr(nullptr, closeAlsaHandle) {
 
 	snd_pcm_t *handle;
-	auto res = snd_pcm_open(&handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
+	auto res = snd_pcm_open(&handle, ALSA_DEVICE, SND_PCM_STREAM_PLAYBACK, 0);
 	if (res != 0)
 		throw std::runtime_error("snd_pcm_open error.");
 

--- a/linux/Sound/AlsaHandle.h
+++ b/linux/Sound/AlsaHandle.h
@@ -13,17 +13,16 @@
     along with libjukebox.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LINUX_ALSAHANDLE_H_
-#define LINUX_ALSAHANDLE_H_
+#ifndef LIBJUKEBOX_LINUX_ALSAHANDLE_2017_12_28_H_
+#define LIBJUKEBOX_LINUX_ALSAHANDLE_2017_12_28_H_
 
-#include <thread>
-#include <memory>
 #include <atomic>
+#include <memory>
+#include <thread>
 #include <alsa/asoundlib.h>
 
-#include "Sound/Sound.h"
-#include "Sound/SoundImpl.h"
-#include "FileFormats/SoundFile.h"
+#include "jukebox/FileFormats/SoundFile.h"
+#include "jukebox/Sound/SoundImpl.h"
 
 namespace jukebox {
 
@@ -52,4 +51,4 @@ private:
 
 } /* namespace jukebox */
 
-#endif /* LINUX_ALSAHANDLE_H_ */
+#endif

--- a/linux/Sound/BUILD
+++ b/linux/Sound/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+	name = "alsa_sound",
+	srcs = ["AlsaHandle.cpp"],
+	hdrs = ["AlsaHandle.h"],
+	deps = [
+		"//jukebox/FileFormats:sound_file",
+		"//jukebox/Sound:sound",
+		"//jukebox/Sound:sound_impl",
+		"@linux_libs//:asound",
+	],
+)


### PR DESCRIPTION
Getting the following error while trying to PLAY files:

ALSA lib pcm.c:8382:(snd_pcm_set_params) Sample format not available for PLAYBACK: Invalid argument
terminate called after throwing an instance of 'std::runtime_error'
  what():  snd_pcm_set_params error.

They load successfully. Am I missing a lib?