### PR TITLE
BUILD files and Sound objects support late init

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,15 @@
-# win32
+module(
+    name = "jukebox",
+    version = "1.0.0",
+    compatibility_level = 1,
+)
+
+new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 
 new_local_repository(
 	name = "win32_libs",
-	path = "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.18362.0/um/x64",
-#	path = "C:/Program Files (x86)/Windows Kits/8.1/Lib/winv6.3/um/x64",
+	# NOTE: replace with your own Windows libraries path
+	path = "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64",
 	build_file_content = """
 package(default_visibility = ["//visibility:public"])
 
@@ -57,4 +63,3 @@ cc_library(
 )
 """,
 )
-

--- a/jukebox/BUILD.bazel
+++ b/jukebox/BUILD.bazel
@@ -4,9 +4,9 @@ package(default_visibility = ["//visibility:public"])
 # you can also use the individual targets in the client side, instead, if you need faster compilation
 
 cc_library(
-    name = "jukebox",
-    deps = [
+	name = "jukebox",
+	deps = [
 		"//jukebox/Mixer:mixer",
 		"//jukebox/Sound:sound",
-    ],
+	],
 )

--- a/jukebox/Decoders/fluidsynth/BUILD
+++ b/jukebox/Decoders/fluidsynth/BUILD
@@ -22,5 +22,4 @@ cc_library(
 		],
 		"//conditions:default": [],
 	}),
-	includes = ["./pthread-win32"],
 )

--- a/jukebox/Decoders/fluidsynth/pthread-win32/BUILD
+++ b/jukebox/Decoders/fluidsynth/pthread-win32/BUILD
@@ -13,4 +13,5 @@ cc_library(
 		"PTW32_STATIC_LIB",
 		"PTW32_BUILD_INLINED",
 	],
+	includes = ["."],
 )

--- a/jukebox/Sound/Sound.cpp
+++ b/jukebox/Sound/Sound.cpp
@@ -40,6 +40,7 @@ class DummyImpl: public SoundImpl {
 	int getVolume() const override { return 0; }
 	void setVolume(int) override {}
 	void loop(bool) override {}
+	void restart() override {}
 	bool playing() const override { return false; }
 	int getPosition() const override { return 0; }
 	void setPosition(int pos) override {}

--- a/jukebox/Sound/Sound.cpp
+++ b/jukebox/Sound/Sound.cpp
@@ -33,6 +33,23 @@ int normalize(int vol) { return std::max(0,std::min(vol,100)); }
 
 namespace jukebox {
 
+class DummyImpl: public SoundImpl {
+	void play() override {}
+	void stop() override {}
+	void pause() override {}
+	int getVolume() const override { return 0; }
+	void setVolume(int) override {}
+	void loop(bool) override {}
+	bool playing() const override { return false; }
+	int getPosition() const override { return 0; }
+	void setPosition(int pos) override {}
+public:
+	DummyImpl(): SoundImpl(0) {}
+};
+
+Sound::Sound() : impl(std::make_unique<DummyImpl>()) {
+}
+
 Sound::Sound(SoundImpl *impl) : impl(impl) {
 }
 

--- a/jukebox/Sound/Sound.h
+++ b/jukebox/Sound/Sound.h
@@ -29,6 +29,7 @@ namespace factory {
 
 class Sound {
 public:
+	Sound();
 	Sound(SoundImpl *impl);
 	Sound(Sound &&) = default;
 	Sound &operator=(Sound &&) = default;

--- a/jukebox_test/data/BUILD.bazel
+++ b/jukebox_test/data/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "sound",
-    srcs = glob([
-        "*.wav",
-    ]),
+	name = "sound",
+	srcs = glob([
+		"*.wav",
+	]),
 )

--- a/jukebox_test/demo/BUILD.bazel
+++ b/jukebox_test/demo/BUILD.bazel
@@ -7,6 +7,11 @@ cc_binary(
 	data = [
 		"//jukebox_test/data:sound",
 	],
+	defines = select({
+		# goes back 6: jukebox_test/demo + 4 more paths
+		"@bazel_tools//src/conditions:windows": ["SOUND_PATH=../../../../../../jukebox_test/data/"],
+		"//conditions:default": [],
+	}),
 )
 
 cc_binary(

--- a/jukebox_test/demo/BUILD.bazel
+++ b/jukebox_test/demo/BUILD.bazel
@@ -27,7 +27,10 @@ cc_binary(
 	],
 	defines = select({
 		# goes back 6: jukebox_test/demo + 4 more paths
-		"@bazel_tools//src/conditions:windows": ["SOUNDFONT_PATH=../../../../../../soundfont/"],
+		"@bazel_tools//src/conditions:windows": [
+			"SOUND_PATH=../../../../../../jukebox_test/data/",
+			"SOUNDFONT_PATH=../../../../../../soundfont/",
+		],
 		"//conditions:default": [],
 	}),
 )

--- a/jukebox_test/demo/main.cpp
+++ b/jukebox_test/demo/main.cpp
@@ -16,7 +16,17 @@
 #include <array>
 #include <iostream>
 #include <string>
-#include "libjukebox.h"
+#include "jukebox/Mixer/Mixer.h"
+#include "jukebox/Sound/Factory.h"
+#include "jukebox/Sound/Sound.h"
+
+#ifdef SOUND_PATH
+#define xstr(a) str(a)
+#define str(a) #a
+std::string soundPath = xstr(SOUND_PATH);
+#else
+std::string soundPath = "";
+#endif
 
 std::string formatDuration(double duration) {
 	int hr = duration/3600;
@@ -48,6 +58,7 @@ int main(int argc, char **argv) {
 	}
 
 	std::string filename1(argv[1]);
+	filename1 = soundPath + filename1;
 
 	std::cout << "ready to load " << filename1 << " as a file" << std::endl;
 

--- a/jukebox_test/demo/soundfontDemo.cpp
+++ b/jukebox_test/demo/soundfontDemo.cpp
@@ -12,13 +12,21 @@ std::string soundFontPath = xstr(SOUNDFONT_PATH);
 std::string soundFontPath = "./soundfont/";
 #endif
 
+#ifdef SOUND_PATH
+#define xstr(a) str(a)
+#define str(a) #a
+std::string soundPath = xstr(SOUND_PATH);
+#else
+std::string soundPath = "";
+#endif
+
 int main(int argc, char **argv) {
 	if( argc < 2 ) {
 		std::cerr << "you need to supply a .mid file as an argument" << std::endl;
 		return 1;
 	}
 
-	auto filename = std::string(argv[1]);
+	auto filename = soundPath + std::string(argv[1]);
 	std::cout << "ready to load " << filename << std::endl;
 	auto soundFile = jukebox::factory::loadFile(filename);
 


### PR DESCRIPTION
* added a Bazel module and BUILD files in all libraries and example applications
* added a default constructor in Sound to support late initialization. default Sound objects use a dummy implementation that does nothing